### PR TITLE
Fix iteration in WriteRegisers

### DIFF
--- a/examples/example_x64.py
+++ b/examples/example_x64.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 Trail of Bits, Inc., all rights reserved.
+
+import microx
+import traceback
+
+if __name__ == "__main__":
+
+    # Disassembly:
+    # push   rbp
+    # mov    rbp,rsp
+    # push   rcx
+    # mov    rax,QWORD PTR [rbp+0x8]
+    # mov    cl,BYTE PTR [rax]
+    # mov    BYTE PTR [rbp-0x1],cl
+    # mov    rsp,rbp
+    # pop    rbp
+    # ret    0x0
+    o = microx.Operations()
+
+    code = microx.ArrayMemoryMap(o, 0x100001000, 0x100002000, can_write=False, can_execute=True)
+    stack = microx.ArrayMemoryMap(o, 0x200080000, 0x200082000)
+
+    code.store_bytes(
+        0x100001000,
+        b"\x55\x48\x89\xe5\x51\x48\x8b\x45\x08\x8a\x08\x88\x4d\xff\x48\x89\xec\x5d\xc2\x00\x00",
+    )
+
+    m = microx.Memory(o, 64)
+    m.add_map(code)
+    m.add_map(stack)
+
+    t = microx.EmptyThread(o)
+    t.write_register("RIP", 0x100001000)
+    t.write_register("RSP", 0x200081000)
+
+    p = microx.Process(o, m)
+
+    try:
+        while True:
+            pc = t.read_register("RIP", t.REG_HINT_PROGRAM_COUNTER)
+            print("Emulating instruction at {:016x}".format(pc))
+            p.execute(t, 1)
+    except Exception as e:
+        print(e)
+        print(traceback.format_exc())
+

--- a/microx/Executor.cpp
+++ b/microx/Executor.cpp
@@ -452,11 +452,12 @@ static bool WriteRegisters(const Executor *executor) {
   xed_reg_enum_t pc_reg = XED_REG_INVALID;
   for (auto i = 0UL; i < gUsedRegs.size(); ++i) {
     const auto reg = static_cast<xed_reg_enum_t>(i);
-    if (i == XED_REG_EIP || i == XED_REG_RIP) {
-      pc_reg = reg;
+    if (!gUsedRegs[i]) {
       continue;
     }
-    if (gModifiedRegs.test(i)) {
+    if (i == XED_REG_EIP || i == XED_REG_RIP) {
+      pc_reg = reg;
+    } else if (gModifiedRegs.test(i)) {
       const auto name = xed_reg_enum_t2str(reg);
       const auto size = xed_get_register_width_bits64(reg);
       const auto store_reg = xed_get_largest_enclosing_register(reg);


### PR DESCRIPTION
Root cause of the broken 64-bit support was the loop in WriteRegisters. I think the intention was to only iterate over registers that are set in the bitset. It is possible that this fix may expose other issues.

Also add a 64-bit example for ease of testing.

Resolves #8.