### PR TITLE
Add support for RDTSC and RDTSCP

### DIFF
--- a/examples/example_tsc.py
+++ b/examples/example_tsc.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 Trail of Bits, Inc., all rights reserved.
+
+import microx
+import traceback
+
+if __name__ == "__main__":
+
+    # Disassembly:
+    # mov eax, 0x55555555
+    # mov edx, eax
+    # rdtsc
+    # mov eax, 0x55555555
+    # mov edx, eax
+    # rdtscp
+
+    o = microx.Operations()
+
+    code = microx.ArrayMemoryMap(o, 0x1000, 0x2000, can_write=False, can_execute=True)
+    stack = microx.ArrayMemoryMap(o, 0x80000, 0x82000)
+
+    code.store_bytes(
+        0x1000,
+        b"\xb8\x55\x55\x55\x55\x89\xc2\x0f\x31\xb8\x55\x55\x55\x55\x89\xc2\x0f\x01\xf9",
+    )
+
+    m = microx.Memory(o, 32)
+    m.add_map(code)
+    m.add_map(stack)
+
+    t = microx.EmptyThread(o)
+    t.write_register("EIP", 0x1000)
+    t.write_register("ESP", 0x81000)
+
+    p = microx.Process(o, m)
+
+    try:
+        while True:
+            pc = t.read_register("EIP", t.REG_HINT_PROGRAM_COUNTER)
+            eax = t.read_register("EAX", t.REG_HINT_GENERAL)
+            edx = t.read_register("EDX", t.REG_HINT_GENERAL)
+            tsc = t.read_register("TSC", t.REG_HINT_NONE)
+            print("Emulating instruction at {:08x} (EAX={:08x}, EDX={:08x}, TSC={:016x})".format(pc, eax, edx, tsc))
+            p.execute(t, 1)
+    except Exception as e:
+        print(e)
+        print(traceback.format_exc())
+

--- a/microx/__init__.py
+++ b/microx/__init__.py
@@ -495,6 +495,10 @@ class Process(Executor):
         self._thread = thread
         try:
             super(Process, self).execute(max_num_instructions)
+
+            # Approximate TSC as 1 cycle / instruction.
+            tsc = self.read_register("TSC", thread.REG_HINT_NONE)
+            self.write_register("TSC", tsc + max_num_instructions)
         finally:
             self._thread = None
 


### PR DESCRIPTION
Fixes #10.

Instead of adding another method for reading the TSC, just use ReadReg. XED already treats TSC and TSCAUX as registers and these will get correctly read by ReadRegisters, provided that WidestRegister is fixed so that it does not turn TSC into INVALID.

This also adds a simple implementation of TSC by incrementing it by max_num_instructions after execute. A user can hook read_register / write_register if they want to do something different with TSC.